### PR TITLE
Fix _delete_data invocations

### DIFF
--- a/SimpleMDMpy/AppGroups.py
+++ b/SimpleMDMpy/AppGroups.py
@@ -36,8 +36,7 @@ class AppGroups(SimpleMDMpy.SimpleMDM.Connection):
     def delete_app_group(self, app_group_id):
         """remove app group"""
         url = self.url + "/" + app_group_id
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args
 
     def assign_app(self, app_group_id, app_id):
         """remove app group from group"""
@@ -48,8 +47,7 @@ class AppGroups(SimpleMDMpy.SimpleMDM.Connection):
     def un_assign_app(self, app_group_id, app_id):
         """unassign app from app group"""
         url = self.url + "/" + app_group_id + "/apps/" + app_id
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args
 
     def assign_device_group(self, app_group_id, device_group_id):
         """assign device group from app group"""
@@ -60,8 +58,7 @@ class AppGroups(SimpleMDMpy.SimpleMDM.Connection):
     def un_assign_device_group(self, app_group_id, device_group_id):
         """remove device group from app group"""
         url = self.url + "/" + app_group_id + "/device_groups/" + device_group_id
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args
 
     def assign_device(self, app_group_id, device_id):
         """assign device to app group"""
@@ -72,8 +69,7 @@ class AppGroups(SimpleMDMpy.SimpleMDM.Connection):
     def un_assign_device(self, app_group_id, device_id):
         """unassign apps in app group"""
         url = self.url + "/" + app_group_id + "/devices/" + str(device_id)
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args
 
     def push_apps(self, app_group_id):
         """push apps in app group"""

--- a/SimpleMDMpy/Apps.py
+++ b/SimpleMDMpy/Apps.py
@@ -46,5 +46,4 @@ class Apps(SimpleMDMpy.SimpleMDM.Connection):
     def delete_app(self, app_id):
         """delete an app"""
         url = self.url + "/" + app_id
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args

--- a/SimpleMDMpy/Devices.py
+++ b/SimpleMDMpy/Devices.py
@@ -38,8 +38,7 @@ class Devices(SimpleMDMpy.SimpleMDM.Connection):
     def delete_device(self, device_id):
         """Unenroll a device and remove it from the account."""
         url = self.url + "/" + str(device_id)
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args
 
     def list_installed_apps(self, device_id):
         """Returns a listing of the apps installed on a device."""

--- a/SimpleMDMpy/Enrollments.py
+++ b/SimpleMDMpy/Enrollments.py
@@ -28,5 +28,4 @@ class Enrollments(SimpleMDMpy.SimpleMDM.Connection):
     def delete_enrollment(self, enrollment_id):
         """delete enrollment"""
         url = self.url + "/" + enrollment_id
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args

--- a/SimpleMDMpy/ManagedAppConfigs.py
+++ b/SimpleMDMpy/ManagedAppConfigs.py
@@ -30,5 +30,4 @@ class ManagedAppConfigs(SimpleMDMpy.SimpleMDM.Connection):
     def delete_config(self, app_id, managed_config_id):
         """Delete managed config from an app by ID."""
         url = self.url + "/" + app_id + "/managed_configs/" + managed_config_id
-        data = {}
-        return self._delete_data(url, data) #pylint: disable=too-many-function-args
+        return self._delete_data(url) #pylint: disable=too-many-function-args


### PR DESCRIPTION
Minor correction, some areas of the codebase pass an empty `data` variable when `SimpleMDM.Connection._delete_data()` only supports a `url` argument:

https://github.com/SteveKueng/simpleMDMpy/blob/3b9ecdfb08f5cec70c55a15300e2dad6f6e4279b/SimpleMDMpy/SimpleMDM.py#L64-L66

Primarily noticed when invoking `Apps.Apps.delete_app()`, but corrected in rest of the codebase as well.

------

Side note, just wanted to say thank you for the this project. Saved me a lot of time and headaches.